### PR TITLE
feat: add dockerfile and docker-compose for building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:18.18-alpine3.18 as builder
+WORKDIR /app
+
+COPY package.json  /app/
+
+RUN yarn install
+
+FROM node:18.18-alpine3.18
+WORKDIR /app
+
+COPY --from=builder /app/node_modules /app/node_modules
+COPY . /app/
+
+EXPOSE 3000
+
+ENV LISTEN_PORT=3000
+ENV LISTEN_HOST=0.0.0.0
+
+CMD ["yarn", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+   auth:
+      build:
+         context: .
+         dockerfile: Dockerfile
+      ports:
+         - 3000:3000


### PR DESCRIPTION
Just a quick feature to add docker support for building this and running it locally without needing to install anything related to node.

It will start the server on port 3000 for local access